### PR TITLE
made the repo page use static generation with a cache of 60 seconds

### DIFF
--- a/pages/repositories.js
+++ b/pages/repositories.js
@@ -37,8 +37,9 @@ export default function Repositories({ repositories }) {
   );
 }
 
-export async function getServerSideProps(context) {
+export async function getStaticProps(context) {
   return {
     props: { repositories: await fetchJson("repositories") },
+    revalidate: 60
   };
 }


### PR DESCRIPTION
This should make the page load faster in general, since the repositories page isn't a live updating page it should be perfectly fine