### PR TITLE
Add pull requests info to progress

### DIFF
--- a/components/PullRequest.js
+++ b/components/PullRequest.js
@@ -1,0 +1,34 @@
+import React from "react";
+
+export default function PullRequest({ repositoryName, sponsorName, url }) {
+  return (
+    <div className="w-full p-2 lg:p-5">
+      <div className="flex flex-col h-full p-5 border-2 border-warm-l-orange rounded-lg">
+        <div>
+          <h2 className="my-2 font-bold text-warm-l-orange tracking-wide">
+            <a
+              href={url.match(/https:\/\/github\.com\/.*\/(?=pull\/\d+)/)[0]}
+              target="_blank"
+            >
+              {sponsorName + "/" + repositoryName}
+            </a>
+          </h2>
+          <div className="flex">
+            <div className="w-full">
+              <img
+                src="/icons/github-logo-128.png"
+                width="25"
+                className="mr-2"
+                alt="github"
+                style={{ display: "inline" }}
+              />
+              <a className="font-bold" href={url} target="_blank">
+                {"#" + url.replace(/https:\/\/github\.com\/.*\/(?=\d+)/, "")}
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/pages/progress.js
+++ b/pages/progress.js
@@ -7,8 +7,9 @@ import MustBeLoggedIn from "../components/MustBeLoggedIn";
 import { fetchJson } from "../lib/api";
 import { getAccountFromSession } from "../lib/user";
 import { info } from "../lib/discord-notifier";
+import PullRequest from "../components/PullRequest";
 
-export default function Progress({ count }) {
+export default function Progress({ count, prs }) {
   const stage = getEventStage();
   const [session] = useSession();
 
@@ -63,6 +64,14 @@ export default function Progress({ count }) {
           {count === 1 && <h2>3 to go!</h2>}
           {count === 2 && <h2>Only 2 left!</h2>}
           {count === 3 && <h2>1 left, so close!</h2>}
+          {prs.map((pr) => (
+            <PullRequest
+              repositoryName={pr.repository_name}
+              sponsorName={pr.sponsor_name}
+              url={pr.url}
+              key={pr.pr_id}
+            />
+          ))}
           {count < 4 && (
             <div className="text-center mt-5">
               <h2>
@@ -87,7 +96,7 @@ export async function getServerSideProps(context) {
 
   const account = await getAccountFromSession(session.accessToken);
 
-  const count = await fetchJson(`users/${account.participant_id}/progress`);
+  const data = await fetchJson(`users/${account.participant_id}/progress`);
 
-  return { props: { count: count.unique } };
+  return { props: { count: data.unique, prs: data.prs } };
 }


### PR DESCRIPTION
This depends on https://github.com/Modtoberfest/Modtoberfest-API/pull/3

Example image (test is client-sided in this case, thus invalid counts):
![image](https://user-images.githubusercontent.com/10366817/95001895-863b4380-059c-11eb-9440-07fdf08a6aba.png)
